### PR TITLE
Scope Powerline exports to pipx branches

### DIFF
--- a/roles/powerline/templates/powerline.bash.j2
+++ b/roles/powerline/templates/powerline.bash.j2
@@ -5,5 +5,7 @@ fi
 if [ -r /usr/share/powerline/bindings/bash/powerline.sh ]; then
   source /usr/share/powerline/bindings/bash/powerline.sh
 elif [ -r "$HOME/.local/pipx/venvs/powerline-status/lib/python3."*/site-packages/powerline/bindings/bash/powerline.sh ]; then
+  export POWERLINE_CONFIG_COMMAND="$HOME/.local/pipx/venvs/powerline-status/bin/powerline-config"
+  export POWERLINE_COMMAND="$HOME/.local/pipx/venvs/powerline-status/bin/powerline"
   source "$HOME/.local/pipx/venvs/powerline-status"/lib/python3.*/site-packages/powerline/bindings/bash/powerline.sh
 fi

--- a/roles/powerline/templates/powerline.tmux.j2
+++ b/roles/powerline/templates/powerline.tmux.j2
@@ -2,5 +2,5 @@
 run-shell 'powerline-daemon -q'
 if-shell '[ -r /usr/share/powerline/bindings/tmux/powerline.conf ]' \
   'source-file /usr/share/powerline/bindings/tmux/powerline.conf' \
-  'if-shell "[ -r $HOME/.local/pipx/venvs/powerline-status/lib/python3.*/site-packages/powerline/bindings/tmux/powerline.conf ]" \
-     "source-file $HOME/.local/pipx/venvs/powerline-status/lib/python3.*/site-packages/powerline/bindings/tmux/powerline.conf" ""'
+  "if-shell '[ -r $HOME/.local/pipx/venvs/powerline-status/lib/python3.*/site-packages/powerline/bindings/tmux/powerline.conf ]' \\
+     'set-environment -g POWERLINE_CONFIG_COMMAND \"$HOME/.local/pipx/venvs/powerline-status/bin/powerline-config" \; set-environment -g POWERLINE_COMMAND \"$HOME/.local/pipx/venvs/powerline-status/bin/powerline" \; source-file $HOME/.local/pipx/venvs/powerline-status/lib/python3.*/site-packages/powerline/bindings/tmux/powerline.conf'"

--- a/roles/powerline/templates/powerline.zsh.j2
+++ b/roles/powerline/templates/powerline.zsh.j2
@@ -5,5 +5,7 @@ fi
 if [[ -r /usr/share/powerline/bindings/zsh/powerline.zsh ]]; then
   source /usr/share/powerline/bindings/zsh/powerline.zsh
 elif [[ -r "$HOME/.local/pipx/venvs/powerline-status"/lib/python3.*/site-packages/powerline/bindings/zsh/powerline.zsh ]]; then
+  export POWERLINE_CONFIG_COMMAND="$HOME/.local/pipx/venvs/powerline-status/bin/powerline-config"
+  export POWERLINE_COMMAND="$HOME/.local/pipx/venvs/powerline-status/bin/powerline"
   source "$HOME/.local/pipx/venvs/powerline-status"/lib/python3.*/site-packages/powerline/bindings/zsh/powerline.zsh
 fi


### PR DESCRIPTION
## Summary
- move Powerline exports into pipx branch of Bash template
- mirror conditional exports for Zsh
- set tmux environment variables only when pipx bindings load

## Testing
- `bash --rcfile roles/powerline/templates/powerline.bash.j2 -i -c 'echo "${POWERLINE_CONFIG_COMMAND:-unset}"'`
- `bash --rcfile roles/powerline/templates/powerline.bash.j2 -i -c 'echo "$POWERLINE_CONFIG_COMMAND"'`
- `ansible-playbook -i inventories/hosts.yml playbooks/powerline.yml -e "powerline_users=['root']" -e powerline_install_method=none` *(command not found)*
- `zsh --version` *(command not found)*
- `tmux -V` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e514ce70832dad5eb35b68f7a8e4