### PR TITLE
Configure Terminator fonts and dev profile in basics role

### DIFF
--- a/roles/basics/README.md
+++ b/roles/basics/README.md
@@ -1,38 +1,54 @@
-Role Name
-=========
+Basics role
+===========
 
-A brief description of the role goes here.
+Installs common desktop tooling and configures the Terminator terminal emulator with a developer-focused profile and curated fonts.
 
 Requirements
 ------------
 
-Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+* Debian or Ubuntu based system with `apt`.
+* Internet access to download font archives from upstream projects and the Nerd Fonts project.
 
 Role Variables
 --------------
 
-A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+| Variable | Default | Description |
+| --- | --- | --- |
+| `basics_packages` | `['terminator', 'p7zip-full', 'redshift', 'flameshot', 'fontconfig', 'unzip']` | Packages installed with `apt`. |
+| `basics_manage_terminator` | `true` | Toggle Terminator configuration and font installation. |
+| `basics_terminator_user` | `{{ ansible_user_id }}` | Account that owns Terminator configuration. |
+| `basics_terminator_group` | `{{ ansible_user_gid | default(ansible_user_id) }}` | Group assigned to Terminator configuration files. |
+| `basics_terminator_user_home` | `{{ ansible_env.HOME }}` | Base path for Terminator configuration files. |
+| `basics_terminator_font_install_dir` | `/usr/local/share/fonts` | Directory where downloaded fonts are installed. |
+| `basics_terminator_font_archives` | see defaults | Font archives (original and Nerd Font versions) that are downloaded and extracted. |
+| `basics_terminator_default_font` | `Hack Nerd Font Mono` | Preferred Terminator font family. |
+| `basics_terminator_default_font_size` | `12` | Default font size for the `dev` profile. |
+| `basics_terminator_profile_name` | `dev` | Name of the Terminator profile created by the role. |
+| `basics_terminator_layout_name` | `dev` | Name of the layout bound to the default profile. |
+| `basics_terminator_profile_settings` | see defaults | Key/value settings rendered inside the profile definition. |
 
 Dependencies
 ------------
 
-A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+This role has no dependencies on external roles.
 
 Example Playbook
 ----------------
 
-Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
-
-    - hosts: servers
-      roles:
-         - { role: username.rolename, x: 42 }
+```yaml
+- hosts: workstation
+  roles:
+    - role: basics
+      vars:
+        basics_terminator_default_font_size: 14
+```
 
 License
 -------
 
-BSD
+MIT-0
 
 Author Information
 ------------------
 
-An optional section for the role authors to include contact information, or a website (HTML is not allowed).
+Maintained by the ansible-home project.

--- a/roles/basics/defaults/main.yml
+++ b/roles/basics/defaults/main.yml
@@ -1,3 +1,63 @@
 #SPDX-License-Identifier: MIT-0
 ---
 # defaults file for basics
+basics_packages:
+  - terminator
+  - p7zip-full
+  - redshift
+  - flameshot
+  - fontconfig
+  - unzip
+
+basics_manage_terminator: true
+
+basics_terminator_user: "{{ ansible_user_id }}"
+basics_terminator_group: "{{ ansible_user_gid | default(ansible_user_id) }}"
+basics_terminator_user_home: "{{ ansible_env.HOME }}"
+
+basics_terminator_font_install_dir: /usr/local/share/fonts
+
+basics_terminator_font_archives:
+  - name: Hack
+    variant: original
+    url: https://github.com/source-foundry/Hack/releases/download/v3.003/Hack-v3.003-ttf.zip
+  - name: Hack
+    variant: nerd
+    url: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.2.1/Hack.zip
+  - name: JetBrains Mono
+    variant: original
+    url: https://download.jetbrains.com/fonts/JetBrainsMono-2.304.zip
+  - name: JetBrains Mono
+    variant: nerd
+    url: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.2.1/JetBrainsMono.zip
+  - name: Fira Code
+    variant: original
+    url: https://github.com/tonsky/FiraCode/releases/download/6.2/Fira_Code_v6.2.zip
+  - name: Fira Code
+    variant: nerd
+    url: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.2.1/FiraCode.zip
+  - name: Cascadia Code
+    variant: original
+    url: https://github.com/microsoft/cascadia-code/releases/download/v2404.23/CascadiaCode-2404.23.zip
+  - name: Cascadia Code
+    variant: nerd
+    url: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.2.1/CascadiaCode.zip
+  - name: Source Code Pro
+    variant: original
+    url: https://github.com/adobe-fonts/source-code-pro/releases/download/2.042R-u/TTF-source-code-pro-2.042R-u.zip
+  - name: Source Code Pro
+    variant: nerd
+    url: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.2.1/SourceCodePro.zip
+
+basics_terminator_default_font: "Hack Nerd Font Mono"
+basics_terminator_default_font_size: 12
+basics_terminator_profile_name: dev
+basics_terminator_layout_name: dev
+basics_terminator_profile_settings:
+  use_system_font: false
+  font: "{{ basics_terminator_default_font }} {{ basics_terminator_default_font_size }}"
+  background_color: "#1e1e1e"
+  foreground_color: "#d4d4d4"
+  cursor_color: "#ffcc00"
+  scrollbar_position: hidden
+

--- a/roles/basics/tasks/main.yml
+++ b/roles/basics/tasks/main.yml
@@ -3,11 +3,11 @@
 - name: Install Basic applications
   become: true
   ansible.builtin.apt:
-    name:
-      - terminator
-      - p7zip-full
-      - redshift
-      - flameshot
+    name: "{{ basics_packages }}"
     state: present
     update_cache: true
-    
+
+- name: Configure Terminator defaults
+  ansible.builtin.import_tasks: terminator.yml
+  when: basics_manage_terminator | bool
+

--- a/roles/basics/tasks/terminator.yml
+++ b/roles/basics/tasks/terminator.yml
@@ -1,0 +1,78 @@
+#SPDX-License-Identifier: MIT-0
+---
+- name: Ensure font installation directory exists
+  become: true
+  ansible.builtin.file:
+    path: "{{ basics_terminator_font_install_dir }}"
+    state: directory
+    mode: "0755"
+
+- name: Create temporary directory for font archives
+  become: true
+  ansible.builtin.tempfile:
+    state: directory
+    suffix: terminator-fonts
+  register: basics_terminator_font_tempdir
+
+- name: Download font archives
+  become: true
+  ansible.builtin.get_url:
+    url: "{{ item.url }}"
+    dest: "{{ basics_terminator_font_tempdir.path }}/{{ item.url | basename }}"
+    mode: "0644"
+  loop: "{{ basics_terminator_font_archives }}"
+  register: basics_terminator_font_downloads
+  loop_control:
+    label: "{{ item.name }} ({{ item.variant }})"
+
+- name: Ensure font variant directory exists
+  become: true
+  ansible.builtin.file:
+    path: "{{ basics_terminator_font_install_dir }}/{{ item.item.name | lower | regex_replace('[^a-z0-9]+', '-') }}/{{ item.item.variant }}"
+    state: directory
+    mode: "0755"
+  loop: "{{ basics_terminator_font_downloads.results }}"
+  loop_control:
+    label: "{{ item.item.name }} ({{ item.item.variant }})"
+
+- name: Install downloaded fonts
+  become: true
+  ansible.builtin.unarchive:
+    src: "{{ item.dest }}"
+    dest: "{{ basics_terminator_font_install_dir }}/{{ item.item.name | lower | regex_replace('[^a-z0-9]+', '-') }}/{{ item.item.variant }}"
+    remote_src: true
+  loop: "{{ basics_terminator_font_downloads.results }}"
+  loop_control:
+    label: "{{ item.item.name }} ({{ item.item.variant }})"
+  register: basics_terminator_font_installations
+
+- name: Refresh font cache
+  become: true
+  ansible.builtin.command: fc-cache -f
+  when: basics_terminator_font_installations is changed
+
+- name: Remove temporary font directory
+  become: true
+  ansible.builtin.file:
+    path: "{{ basics_terminator_font_tempdir.path }}"
+    state: absent
+  when: basics_terminator_font_tempdir.path is defined
+
+- name: Ensure Terminator configuration directory exists
+  become: true
+  ansible.builtin.file:
+    path: "{{ basics_terminator_user_home }}/.config/terminator"
+    state: directory
+    owner: "{{ basics_terminator_user }}"
+    group: "{{ basics_terminator_group }}"
+    mode: "0700"
+
+- name: Deploy Terminator configuration
+  become: true
+  ansible.builtin.template:
+    src: terminator/config.j2
+    dest: "{{ basics_terminator_user_home }}/.config/terminator/config"
+    owner: "{{ basics_terminator_user }}"
+    group: "{{ basics_terminator_group }}"
+    mode: "0600"
+

--- a/roles/basics/templates/terminator/config.j2
+++ b/roles/basics/templates/terminator/config.j2
@@ -1,0 +1,41 @@
+#SPDX-License-Identifier: MIT-0
+[global_config]
+  default_profile = {{ basics_terminator_profile_name }}
+  suppress_multiple_term_dialog = True
+
+[keybindings]
+
+[profiles]
+  [[{{ basics_terminator_profile_name }}]]
+{% for key, value in basics_terminator_profile_settings | dictsort %}{% if value is boolean %}
+    {{ key }} = {{ value | ternary('True', 'False') }}
+{% else %}
+    {{ key }} = {{ value }}
+{% endif %}{% endfor %}
+  [[default]]
+{% for key, value in basics_terminator_profile_settings | dictsort %}{% if value is boolean %}
+    {{ key }} = {{ value | ternary('True', 'False') }}
+{% else %}
+    {{ key }} = {{ value }}
+{% endif %}{% endfor %}
+
+[layouts]
+  [[{{ basics_terminator_layout_name }}]]
+    [[[child1]]]
+      type = Terminal
+      parent = window0
+      profile = {{ basics_terminator_profile_name }}
+    [[[window0]]]
+      type = Window
+      parent = ""
+  [[default]]
+    [[[child1]]]
+      type = Terminal
+      parent = window0
+      profile = {{ basics_terminator_profile_name }}
+    [[[window0]]]
+      type = Window
+      parent = ""
+
+[plugins]
+


### PR DESCRIPTION
## Summary
- manage core desktop packages via a configurable list in the basics role
- download and install Hack plus four other popular developer fonts in both original and Nerd Font variants
- ship a templated Terminator configuration that sets a dev profile with the Hack Nerd Font as default

## Testing
- `ansible-playbook roles/basics/tests/test.yml --syntax-check` *(fails: ansible-playbook command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce8e3720e4832dbb471fe67aefa637