### PR TITLE
Support configuring Terminator for multiple users

### DIFF
--- a/roles/basics/README.md
+++ b/roles/basics/README.md
@@ -16,9 +16,7 @@ Role Variables
 | --- | --- | --- |
 | `basics_packages` | `['terminator', 'p7zip-full', 'redshift', 'flameshot', 'fontconfig', 'unzip']` | Packages installed with `apt`. |
 | `basics_manage_terminator` | `true` | Toggle Terminator configuration and font installation. |
-| `basics_terminator_user` | `{{ ansible_user_id }}` | Account that owns Terminator configuration. |
-| `basics_terminator_group` | `{{ ansible_user_gid | default(ansible_user_id) }}` | Group assigned to Terminator configuration files. |
-| `basics_terminator_user_home` | `{{ ansible_env.HOME }}` | Base path for Terminator configuration files. |
+| `basics_terminator_users` | `[{'name': '{{ ansible_user_id }}', 'group': '{{ ansible_user_gid | default(ansible_user_id) }}', 'home': '{{ ansible_env.HOME }}'}]` | List of accounts that receive Terminator configuration. Each entry may be a username string or a mapping with `name`, `group`, and `home`. |
 | `basics_terminator_font_install_dir` | `/usr/local/share/fonts` | Directory where downloaded fonts are installed. |
 | `basics_terminator_font_archives` | see defaults | Font archives (original and Nerd Font versions) that are downloaded and extracted. |
 | `basics_terminator_default_font` | `Hack Nerd Font Mono` | Preferred Terminator font family. |

--- a/roles/basics/defaults/main.yml
+++ b/roles/basics/defaults/main.yml
@@ -11,9 +11,10 @@ basics_packages:
 
 basics_manage_terminator: true
 
-basics_terminator_user: "{{ ansible_user_id }}"
-basics_terminator_group: "{{ ansible_user_gid | default(ansible_user_id) }}"
-basics_terminator_user_home: "{{ ansible_env.HOME }}"
+basics_terminator_users:
+  - name: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_gid | default(ansible_user_id) }}"
+    home: "{{ ansible_env.HOME }}"
 
 basics_terminator_font_install_dir: /usr/local/share/fonts
 

--- a/roles/basics/tasks/terminator.yml
+++ b/roles/basics/tasks/terminator.yml
@@ -83,17 +83,33 @@
 - name: Ensure Terminator configuration directory exists
   become: true
   ansible.builtin.file:
-    path: "{{ basics_terminator_user_home }}/.config/terminator"
+    path: "{{ terminator_user_home }}/.config/terminator"
     state: directory
-    owner: "{{ basics_terminator_user }}"
-    group: "{{ basics_terminator_group }}"
+    owner: "{{ terminator_user_name }}"
+    group: "{{ terminator_user_group }}"
     mode: "0700"
+  loop: "{{ basics_terminator_users }}"
+  loop_control:
+    loop_var: terminator_user
+    label: "{{ terminator_user_name }}"
+  vars:
+    terminator_user_name: "{{ terminator_user.name | default(terminator_user) }}"
+    terminator_user_group: "{{ terminator_user.group | default(terminator_user_name) }}"
+    terminator_user_home: "{{ terminator_user.home | default('/home/' ~ terminator_user_name) }}"
 
 - name: Deploy Terminator configuration
   become: true
   ansible.builtin.template:
     src: terminator/config.j2
-    dest: "{{ basics_terminator_user_home }}/.config/terminator/config"
-    owner: "{{ basics_terminator_user }}"
-    group: "{{ basics_terminator_group }}"
+    dest: "{{ terminator_user_home }}/.config/terminator/config"
+    owner: "{{ terminator_user_name }}"
+    group: "{{ terminator_user_group }}"
     mode: "0600"
+  loop: "{{ basics_terminator_users }}"
+  loop_control:
+    loop_var: terminator_user
+    label: "{{ terminator_user_name }}"
+  vars:
+    terminator_user_name: "{{ terminator_user.name | default(terminator_user) }}"
+    terminator_user_group: "{{ terminator_user.group | default(terminator_user_name) }}"
+    terminator_user_home: "{{ terminator_user.home | default('/home/' ~ terminator_user_name) }}"


### PR DESCRIPTION
## Summary
- allow the basics role to manage Terminator configuration for a list of users instead of a single account
- loop per-user when creating Terminator directories and templates, supporting both simple usernames and custom home/group overrides
- document the new `basics_terminator_users` variable in the role README

## Testing
- `ansible-playbook roles/basics/tests/test.yml --syntax-check` *(fails: command not found: ansible-playbook)*

------
https://chatgpt.com/codex/tasks/task_e_68d0780aca50832dba806a8ca57c23f7