### PR TITLE
Simplify basics terminator user defaults

### DIFF
--- a/roles/basics/README.md
+++ b/roles/basics/README.md
@@ -16,7 +16,7 @@ Role Variables
 | --- | --- | --- |
 | `basics_packages` | `['terminator', 'p7zip-full', 'redshift', 'flameshot', 'fontconfig', 'unzip']` | Packages installed with `apt`. |
 | `basics_manage_terminator` | `true` | Toggle Terminator configuration and font installation. |
-| `basics_terminator_users` | `[{'name': '{{ ansible_user_id }}', 'group': '{{ ansible_user_gid | default(ansible_user_id) }}', 'home': '{{ ansible_env.HOME }}'}]` | List of accounts that receive Terminator configuration. Each entry may be a username string or a mapping with `name`, `group`, and `home`. |
+| `basics_terminator_users` | `['{{ ansible_user_id }}']` | List of usernames that receive Terminator configuration. Each account is assumed to have a matching primary group and home directory at `/home/<username>`. |
 | `basics_terminator_font_install_dir` | `/usr/local/share/fonts` | Directory where downloaded fonts are installed. |
 | `basics_terminator_font_archives` | see defaults | Font archives (original and Nerd Font versions) that are downloaded and extracted. |
 | `basics_terminator_default_font` | `Hack Nerd Font Mono` | Preferred Terminator font family. |

--- a/roles/basics/defaults/main.yml
+++ b/roles/basics/defaults/main.yml
@@ -12,9 +12,7 @@ basics_packages:
 basics_manage_terminator: true
 
 basics_terminator_users:
-  - name: "{{ ansible_user_id }}"
-    group: "{{ ansible_user_gid | default(ansible_user_id) }}"
-    home: "{{ ansible_env.HOME }}"
+  - "{{ ansible_user_id }}"
 
 basics_terminator_font_install_dir: /usr/local/share/fonts
 

--- a/roles/basics/tasks/terminator.yml
+++ b/roles/basics/tasks/terminator.yml
@@ -83,33 +83,25 @@
 - name: Ensure Terminator configuration directory exists
   become: true
   ansible.builtin.file:
-    path: "{{ terminator_user_home }}/.config/terminator"
+    path: "/home/{{ terminator_user }}/.config/terminator"
     state: directory
-    owner: "{{ terminator_user_name }}"
-    group: "{{ terminator_user_group }}"
+    owner: "{{ terminator_user }}"
+    group: "{{ terminator_user }}"
     mode: "0700"
   loop: "{{ basics_terminator_users }}"
   loop_control:
     loop_var: terminator_user
-    label: "{{ terminator_user_name }}"
-  vars:
-    terminator_user_name: "{{ terminator_user.name | default(terminator_user) }}"
-    terminator_user_group: "{{ terminator_user.group | default(terminator_user_name) }}"
-    terminator_user_home: "{{ terminator_user.home | default('/home/' ~ terminator_user_name) }}"
+    label: "{{ terminator_user }}"
 
 - name: Deploy Terminator configuration
   become: true
   ansible.builtin.template:
     src: terminator/config.j2
-    dest: "{{ terminator_user_home }}/.config/terminator/config"
-    owner: "{{ terminator_user_name }}"
-    group: "{{ terminator_user_group }}"
+    dest: "/home/{{ terminator_user }}/.config/terminator/config"
+    owner: "{{ terminator_user }}"
+    group: "{{ terminator_user }}"
     mode: "0600"
   loop: "{{ basics_terminator_users }}"
   loop_control:
     loop_var: terminator_user
-    label: "{{ terminator_user_name }}"
-  vars:
-    terminator_user_name: "{{ terminator_user.name | default(terminator_user) }}"
-    terminator_user_group: "{{ terminator_user.group | default(terminator_user_name) }}"
-    terminator_user_home: "{{ terminator_user.home | default('/home/' ~ terminator_user_name) }}"
+    label: "{{ terminator_user }}"


### PR DESCRIPTION
## Summary
- default the basics Terminator user list to simple usernames so the role assumes standard Linux group and home paths
- adjust the Terminator tasks to always use the username-based group and home conventions
- update the documentation to describe the implicit group and home assumptions

## Testing
- not run (ansible-lint not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d0893d83ec832d8767a6e3a2668d42