### PR TITLE
Quote Terminator profile colors to avoid invalid CSS colors

### DIFF
--- a/roles/basics/templates/terminator/config.j2
+++ b/roles/basics/templates/terminator/config.j2
@@ -9,12 +9,16 @@
   [[{{ basics_terminator_profile_name }}]]
 {% for key, value in basics_terminator_profile_settings | dictsort %}{% if value is boolean %}
     {{ key }} = {{ value | ternary('True', 'False') }}
+{% elif value is string and '#' in value %}
+    {{ key }} = "{{ value }}"
 {% else %}
     {{ key }} = {{ value }}
 {% endif %}{% endfor %}
   [[default]]
 {% for key, value in basics_terminator_profile_settings | dictsort %}{% if value is boolean %}
     {{ key }} = {{ value | ternary('True', 'False') }}
+{% elif value is string and '#' in value %}
+    {{ key }} = "{{ value }}"
 {% else %}
     {{ key }} = {{ value }}
 {% endif %}{% endfor %}


### PR DESCRIPTION
## Summary
- quote Terminator profile settings that contain hash characters when rendering the config template
- prevent ConfigObj from stripping color values that caused Terminator to crash when loading its CSS theme

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d14e2eeb5c832d938db491bf7b1dff