### PR TITLE
Refine Terminator configuration template

### DIFF
--- a/roles/basics/README.md
+++ b/roles/basics/README.md
@@ -19,11 +19,14 @@ Role Variables
 | `basics_terminator_users` | `['{{ ansible_user_id }}']` | List of usernames that receive Terminator configuration. Each account is assumed to have a matching primary group and home directory at `/home/<username>`. |
 | `basics_terminator_font_install_dir` | `/usr/local/share/fonts` | Directory where downloaded fonts are installed. |
 | `basics_terminator_font_archives` | see defaults | Font archives (original and Nerd Font versions) that are downloaded and extracted. |
-| `basics_terminator_default_font` | `Hack Nerd Font Mono` | Preferred Terminator font family. |
-| `basics_terminator_default_font_size` | `12` | Default font size for the `dev` profile. |
-| `basics_terminator_profile_name` | `dev` | Name of the Terminator profile created by the role. |
-| `basics_terminator_layout_name` | `dev` | Name of the layout bound to the default profile. |
-| `basics_terminator_profile_settings` | see defaults | Key/value settings rendered inside the profile definition. |
+| `basics_terminator_default_font_family` | `FiraCode Nerd Font Propo` | Base font family applied to the default and Dracula profiles. |
+| `basics_terminator_default_font_variant` | `Medium` | Optional weight/variant appended to the default profile font string. Use `null` to omit. |
+| `basics_terminator_default_font_size` | `14` | Font size applied when composing profile font declarations. |
+| `basics_terminator_default_profile_name` | `null` | When set, renders `default_profile` inside the global Terminator configuration. |
+| `basics_terminator_global_config_comments` | `['  # Dracula Globals']` | Comment lines inserted after the optional `default_profile` declaration. |
+| `basics_terminator_global_config` | see defaults | Key/value pairs rendered in the `[global_config]` section. |
+| `basics_terminator_profiles` | see defaults | Map of profile names to their key/value settings. |
+| `basics_terminator_layouts` | see defaults | Map of layout names to child terminal and window definitions. |
 
 Dependencies
 ------------
@@ -38,7 +41,9 @@ Example Playbook
   roles:
     - role: basics
       vars:
-        basics_terminator_default_font_size: 14
+        basics_terminator_default_font_family: "JetBrainsMono Nerd Font"
+        basics_terminator_default_font_variant: null
+        basics_terminator_default_font_size: 13
 ```
 
 License

--- a/roles/basics/defaults/main.yml
+++ b/roles/basics/defaults/main.yml
@@ -51,15 +51,77 @@ basics_terminator_font_archives:
     variant: nerd
     url: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.2.1/SourceCodePro.zip
 
-basics_terminator_default_font: "Hack Nerd Font Mono"
-basics_terminator_default_font_size: 12
-basics_terminator_profile_name: dev
-basics_terminator_layout_name: dev
-basics_terminator_profile_settings:
-  use_system_font: false
-  font: "{{ basics_terminator_default_font }} {{ basics_terminator_default_font_size }}"
-  background_color: "#1e1e1e"
-  foreground_color: "#d4d4d4"
-  cursor_color: "#ffcc00"
-  scrollbar_position: hidden
+basics_terminator_default_font_family: "FiraCode Nerd Font Propo"
+basics_terminator_default_font_variant: "Medium"
+basics_terminator_default_font_size: 14
+basics_terminator_default_profile_name: null
+basics_terminator_global_config_comments:
+  - "  # Dracula Globals"
+basics_terminator_global_config:
+  enabled_plugins:
+    - Logger
+    - LaunchpadBugURLHandler
+    - LaunchpadCodeURLHandler
+    - APTURLHandler
+    - TerminalShot
+  suppress_multiple_term_dialog: true
+  always_split_with_profile: true
+  title_transmit_fg_color: "#282a36"
+  title_transmit_bg_color: "#50fa7b"
+  title_receive_fg_color: "#282a36"
+  title_receive_bg_color: "#ff79c6"
+  title_inactive_fg_color: "#f8f8f2"
+  title_inactive_bg_color: "#44475a"
+  inactive_color_offset: 0.61
+  title_hide_sizetext: true
+basics_terminator_profiles:
+  default:
+    background_color: "#282a36"
+    background_image: null
+    font: "{{ basics_terminator_default_font_family }}{% if basics_terminator_default_font_variant %} {{ basics_terminator_default_font_variant }}{% endif %} {{ basics_terminator_default_font_size }}"
+    foreground_color: "#f8f8f2"
+    palette: "#262626:#e356a7:#42e66c:#e4f34a:#9b6bdf:#e64747:#75d7ec:#efa554:#7a7a7a:#ff79c6:#50fa7b:#f1fa8c:#bd93f9:#ff5555:#8be9fd:#ffb86c"
+    use_system_font: false
+  dev:
+    background_color: "#1e1e1e"
+    font: "{{ basics_terminator_default_font_family }} {{ basics_terminator_default_font_size }}"
+    foreground_color: "#d4d4d4"
+    scrollbar_position: hidden
+    use_system_font: false
+  dracula:
+    background_color: "#282a36"
+    background_image: null
+    font: "{{ basics_terminator_default_font_family }}{% if basics_terminator_default_font_variant %} {{ basics_terminator_default_font_variant }}{% endif %} {{ basics_terminator_default_font_size }}"
+    foreground_color: "#f8f8f2"
+    palette: "#262626:#e356a7:#42e66c:#e4f34a:#9b6bdf:#e64747:#75d7ec:#efa554:#7a7a7a:#ff79c6:#50fa7b:#f1fa8c:#bd93f9:#ff5555:#8be9fd:#ffb86c"
+    use_system_font: false
+  solarized-dark:
+    background_color: "#002b36"
+    foreground_color: "#eee8d5"
+    palette: "#073642:#dc322f:#859900:#b58900:#268bd2:#d33682:#2aa198:#eee8d5:#586e75:#cb4b16:#586e75:#657b83:#839496:#6c71c4:#93a1a1:#fdf6e3"
+  solarized-light:
+    background_color: "#eee8d5"
+    foreground_color: "#002b36"
+    palette: "#073642:#dc322f:#859900:#b58900:#268bd2:#d33682:#2aa198:#eee8d5:#002b36:#cb4b16:#586e75:#657b83:#839496:#6c71c4:#93a1a1:#fdf6e3"
+basics_terminator_layouts:
+  default:
+    children:
+      child1:
+        type: Terminal
+        parent: window0
+        profile: default
+    windows:
+      window0:
+        type: Window
+        parent: ""
+  dev:
+    children:
+      child1:
+        type: Terminal
+        parent: window0
+        profile: dev
+    windows:
+      window0:
+        type: Window
+        parent: ""
 

--- a/roles/basics/templates/terminator/config.j2
+++ b/roles/basics/templates/terminator/config.j2
@@ -1,45 +1,69 @@
 #SPDX-License-Identifier: MIT-0
+{% macro terminator_value(value) -%}
+{%- if value is boolean -%}
+{{ value | ternary('True', 'False') }}
+{%- elif value is none -%}
+None
+{%- elif value is number -%}
+{{ value }}
+{%- elif value is string -%}
+{%- if '#' in value -%}
+"{{ value }}"
+{%- else -%}
+{{ value }}
+{%- endif -%}
+{%- elif value is sequence -%}
+{{ value | join(', ') }}
+{%- else -%}
+{{ value }}
+{%- endif -%}
+{%- endmacro %}
+
+{% set global_config = basics_terminator_global_config | default({}, true) %}
+{% set global_config_comments = basics_terminator_global_config_comments | default([], true) %}
+{% set default_profile = basics_terminator_default_profile_name | default('', true) %}
+{% set profiles = basics_terminator_profiles | default({}, true) %}
+{% set layouts = basics_terminator_layouts | default({}, true) %}
+
 [global_config]
-  default_profile = {{ basics_terminator_profile_name }}
-  suppress_multiple_term_dialog = True
+{% if default_profile %}
+  default_profile = {{ default_profile }}
+{% endif %}
+{% for comment in global_config_comments %}
+{{ comment }}
+{% endfor %}
+{% for key, value in global_config.items() %}
+  {{ key }} = {{ terminator_value(value) }}
+{% endfor %}
 
 [keybindings]
 
 [profiles]
-  [[{{ basics_terminator_profile_name }}]]
-{% for key, value in basics_terminator_profile_settings | dictsort %}{% if value is boolean %}
-    {{ key }} = {{ value | ternary('True', 'False') }}
-{% elif value is string and '#' in value %}
-    {{ key }} = "{{ value }}"
-{% else %}
-    {{ key }} = {{ value }}
-{% endif %}{% endfor %}
-  [[default]]
-{% for key, value in basics_terminator_profile_settings | dictsort %}{% if value is boolean %}
-    {{ key }} = {{ value | ternary('True', 'False') }}
-{% elif value is string and '#' in value %}
-    {{ key }} = "{{ value }}"
-{% else %}
-    {{ key }} = {{ value }}
-{% endif %}{% endfor %}
+{% for profile_name, profile_settings in profiles.items() %}
+  [[{{ profile_name }}]]
+{% for key, value in profile_settings.items() %}
+    {{ key }} = {{ terminator_value(value) }}
+{% endfor %}
+{% endfor %}
 
 [layouts]
-  [[{{ basics_terminator_layout_name }}]]
-    [[[child1]]]
-      type = Terminal
-      parent = window0
-      profile = {{ basics_terminator_profile_name }}
-    [[[window0]]]
-      type = Window
-      parent = ""
-  [[default]]
-    [[[child1]]]
-      type = Terminal
-      parent = window0
-      profile = {{ basics_terminator_profile_name }}
-    [[[window0]]]
-      type = Window
-      parent = ""
+{% for layout_name, layout_settings in layouts.items() %}
+  [[{{ layout_name }}]]
+{% set child_terminals = layout_settings.children | default({}, true) %}
+{% set windows = layout_settings.windows | default({}, true) %}
+{% for child_name, child_settings in child_terminals.items() %}
+    [[[{{ child_name }}]]]
+{% for key, value in child_settings.items() %}
+      {{ key }} = {{ terminator_value(value) }}
+{% endfor %}
+{% endfor %}
+{% for window_name, window_settings in windows.items() %}
+    [[[{{ window_name }}]]]
+{% for key, value in window_settings.items() %}
+      {{ key }} = {{ terminator_value(value) }}
+{% endfor %}
+{% endfor %}
+{% endfor %}
 
 [plugins]
 


### PR DESCRIPTION
## Summary
- extend the Terminator configuration template with a reusable value formatter and support for data-driven global settings, profiles, and layouts
- update the role defaults to match the Dracula-inspired configuration while keeping font declarations derived from overridable base variables
- document the new Terminator variables and example overrides in the basics role README

## Testing
- ⚠️ `ansible localhost -m ansible.builtin.template -a "src=/workspace/ansible-home/roles/basics/templates/terminator/config.j2 dest=/tmp/terminator.conf" -i localhost, -c local -e ansible_user_id=testuser -e @/workspace/ansible-home/roles/basics/defaults/main.yml` *(fails: `ansible` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2d3fcf3f8832db33003721b3b6975